### PR TITLE
Update London Inflation and Tenure, and India Inflation

### DIFF
--- a/source/rent_vs_buy.py
+++ b/source/rent_vs_buy.py
@@ -10,14 +10,14 @@ typical house in London
 #
 # interest_rate = 0.055
 # down_payment = 0.2
-# tenure = 15
+# tenure = 30
 # yearly_savings_return = 0.06
 # property_price_appreciation = 0.04
 #
 # rent_percentage = 0.05  # rental yield
 # rent_maintenance_per = 0.1  # amount of the rent that goes to maintenance, property tax, etc.
 #
-# inflation = 0.03
+# inflation = 0.02
 
 # -------------------------------------------------------------------------------------------------------------------------------
 """

--- a/source/rent_vs_buy.py
+++ b/source/rent_vs_buy.py
@@ -35,7 +35,7 @@ property_price_appreciation = 0.07
 rent_percentage = 0.023  # rental yield
 rent_maintenance_per = 0.07  # amount of the rent that goes to maintenance, property tax, etc.
 
-inflation = 0.06
+inflation = 0.04
 
 # -------------------------------------------------------------------------------------------------------------------------------
 """


### PR DESCRIPTION
Closes #2

Change Inflation to 2% because that is UK's inflation target (https://www.bankofengland.co.uk/monetary-policy/inflation), and average mortgage tenure is 30 years.

Additionally, Reserve Bank of India's Inflation target is 4% (https://rbi.org.in/scripts/FS_Overview.aspx?fn=2752) so it is more appropriate to change Inflation value from 6% to 4%.

Inflation Expectations are anchored by the Central Bank's target rates, which is why I believe it is appropriate to make the Inflation values match the Central Bank's targets.